### PR TITLE
v4.6.3 — Security & Performance release

### DIFF
--- a/markup-by-attribute-for-woocommerce.php
+++ b/markup-by-attribute-for-woocommerce.php
@@ -85,7 +85,7 @@ function enqueue_custom_admin_styles(string $hook): void {
 
 	if (($hook === 'post.php' || $hook === 'post-new.php') && $post_type === 'product') {
 		$css_url = plugin_dir_url(__FILE__) . 'src/css/admin-style.css';
-		wp_enqueue_style('custom-admin-style', $css_url);
+		wp_enqueue_style('mt2mba-admin-styles', $css_url, array(), MT2MBA_VERSION);
 	}
 }
 add_action('admin_enqueue_scripts', __NAMESPACE__ . '\enqueue_custom_admin_styles');

--- a/markup-by-attribute-for-woocommerce.php
+++ b/markup-by-attribute-for-woocommerce.php
@@ -4,6 +4,7 @@ namespace mt2Tech\MarkupByAttribute;
 use mt2Tech\MarkupByAttribute\Backend as Backend;
 use mt2Tech\MarkupByAttribute\Frontend as Frontend;
 use mt2Tech\MarkupByAttribute\Utility as Utility;
+use Throwable;
 
 /**
  * Markup by Attribute for WooCommerce
@@ -197,7 +198,7 @@ function mt2mba_run_upgrades(): void {
 			(new $fqcn)->run();
 			// Re-read in case the upgrade stamped its version
 			$installed_version = get_option('mt2mba_db_version', '0');
-		} catch (\Exception $e) {
+		} catch (Throwable $e) {
 			set_transient('mt2mba_upgrade_cooldown', true, HOUR_IN_SECONDS);
 			if (defined('WP_DEBUG') && WP_DEBUG) {
 				error_log('MT2MBA upgrade failed at version ' . $fqcn::version() . ': ' . $e->getMessage());

--- a/markup-by-attribute-for-woocommerce.php
+++ b/markup-by-attribute-for-woocommerce.php
@@ -129,17 +129,17 @@ function define_constants(): void {
 	define('MT2MBA_PRICE_META', __('Product price', MT2MBA_TEXT_DOMAIN) . ' ');
 	define('MT2MBA_MARKUP_NAME_PATTERN_ADD', '(' . __('Add', MT2MBA_TEXT_DOMAIN) . ' %s)');
 	define('MT2MBA_MARKUP_NAME_PATTERN_SUBTRACT', '(' . __('Subtract', MT2MBA_TEXT_DOMAIN) . ' %s)');
-	define('PRODUCT_MARKUP_DESC_BEG', '<span id="mbainfo">');
-	define('PRODUCT_MARKUP_DESC_END', '</span>');
+	define('MT2MBA_PRODUCT_MARKUP_DESC_BEG', '<span id="mbainfo">');
+	define('MT2MBA_PRODUCT_MARKUP_DESC_END', '</span>');
 
 	// Option and meta key prefixes
-	define('REWRITE_TERM_NAME_PREFIX', 'mt2mba_rewrite_attrb_name_');
-	define('REWRITE_TERM_DESC_PREFIX', 'mt2mba_rewrite_attrb_desc_');
-	define('DONT_OVERWRITE_THEME_PREFIX', 'mt2mba_dont_overwrite_theme_');
+	define('MT2MBA_REWRITE_TERM_NAME_PREFIX', 'mt2mba_rewrite_attrb_name_');
+	define('MT2MBA_REWRITE_TERM_DESC_PREFIX', 'mt2mba_rewrite_attrb_desc_');
+	define('MT2MBA_DONT_OVERWRITE_THEME_PREFIX', 'mt2mba_dont_overwrite_theme_');
 
 	// Price type constants (Used by WooCommerce, do not translate)
-	define('REGULAR_PRICE', 'regular_price');
-	define('SALE_PRICE', 'sale_price');
+	define('MT2MBA_REGULAR_PRICE', 'regular_price');
+	define('MT2MBA_SALE_PRICE', 'sale_price');
 }
 
 /**

--- a/markup-by-attribute-for-woocommerce.php
+++ b/markup-by-attribute-for-woocommerce.php
@@ -12,7 +12,7 @@ use Throwable;
  * This file is part of the Markup by Attribute for WooCommerce plugin by Mark Tomlinson
  *
  * @package   markup-by-attribute-for-woocommerce
- * @version   4.6.2
+ * @version   4.6.3
  * @author    Mark Tomlinson
  * @license   GPL-2.0+
  */
@@ -29,18 +29,18 @@ use Throwable;
  * License URI:             https://www.gnu.org/licenses/gpl-3.0.html
  * Text Domain:             markup-by-attribute-for-woocommerce
  * Domain Path:             /languages
- * Version:                 4.6.2
- * Stable tag:              4.6.2
+ * Version:                 4.6.3
+ * Stable tag:              4.6.3
  * Tested up to:            7.0
  * Requires at least:       5.7
- * PHP tested up to:        8.4.11
+ * PHP tested up to:        8.4.21
  * Requires PHP:            7.4.3
  * NOTE: Union types (e.g., string|float) require PHP 8.0+. Some method parameters
  *       accept multiple types at runtime but are typed as string for 7.4 compatibility.
  *       See affected method docblocks for details.
- * WC tested up to:         10.6.2
+ * WC tested up to:         10.8.1
  * WC requires at least:    5.0.0
- * MySQL tested up to:      8.4.8
+ * MariaDB tested up to:    11.8.6
  */
 
 // Sanity check. Exit if accessed directly.
@@ -115,7 +115,7 @@ function define_constants(): void {
 	define('MT2MBA_SITE_URL', get_bloginfo('wpurl'));
 
 	// Plugin version and compatibility
-	define('MT2MBA_VERSION', '4.6.2');
+	define('MT2MBA_VERSION', '4.6.3');
 	define('MT2MBA_SCHEMA_VERSION', '4.6.0');	// Last plugin version that included a database schema change
 	define('MT2MBA_ADMIN_POINTER_PRIORITY', 1000);
 

--- a/readme.txt
+++ b/readme.txt
@@ -9,15 +9,15 @@ Contributors:			MarkTomlinson
 Donate link:			https://github.com/Mark-Tomlinson/markup-by-attribute-for-woocommerce/wiki/4.0_Donate
 License:				GPLv3
 License URI:			https://www.gnu.org/licenses/gpl-3.0.html
-Version:                4.6.2
-Stable tag:             4.6.2
+Version:                4.6.3
+Stable tag:             4.6.3
 Tested up to:           7.0
 Requires at least:      5.7
-PHP tested up to:       8.4.11
+PHP tested up to:       8.4.21
 Requires PHP:           7.4.3
-WC tested up to:        10.6.2
+WC tested up to:        10.8.1
 WC requires at least:   5.0.0
-MySQL tested up to:     8.4.8
+MariaDB tested up to:   11.8.6
 
 This plugin adds product variation markup by attribute to WooCommerce and adjusts product variation regular and sale prices accordingly.
 
@@ -200,6 +200,9 @@ If you use Markup-by-Attribute and want to see me continue support for it, I enc
 7. The settings page allows configuration of how the markup is displayed.
 
 == Upgrade Notice ==
+= 4.6.3 =
+Security and performance update: hardened AJAX permission checks, closed a translation-based XSS vector in wp-admin, made markup reapplication fully atomic, fixed several edge-case bugs, and improved admin and storefront performance. Recommended for all users.
+
 = 4.6.2 =
 Cosmetic update. Adds a Donate link to the plugin action links and improves the Settings page layout. No functional changes.
 
@@ -210,6 +213,31 @@ Compatibility update for WordPress 7.0 and WooCommerce 10.6.2. No functional cha
 Removed the "Preserve Zero Prices" setting. If you had this enabled and have free products with global attribute markups, see the wiki for details.
 
 == Changelog ==
+= 4.6.3 =
+*Release Date: June 2026*
+
+**Security**
+* Added capability checks (edit_products / manage_product_terms) to all AJAX handlers and attribute option writes, alongside existing nonce checks
+* Escaped all admin-facing output to close a stored-XSS vector via malicious or compromised translation files
+* Escaped literal underscores in meta-key LIKE queries so cleanup matches only intended keys
+* Prefixed all global PHP constants with MT2MBA_ to avoid collisions with other plugins
+
+**Bug Fixes**
+* Markup reapplication is now truly atomic — fixed nested-transaction handling so a mid-run failure rolls back every price change instead of leaving partial updates
+* Invalidate variation caches after bulk price edits so a stale cache can't revert changes when the product is saved
+* Stopped the Markup term column from wiping content other plugins add to the attribute term list
+* Fixed a possible regular-expression error when stripping markup annotations under certain translations
+* Fixed the term-save recursion guard so batch term updates process every term, not just the first
+
+**Performance**
+* Product list no longer loads product data for columns belonging to other plugins
+* Attribute filter uses an EXISTS clause and runs only on the main admin query
+* Removed a redundant taxonomy-ID lookup on the storefront product page
+
+**Maintenance**
+* Versioned and gated admin script/style enqueues (cache-busting, and loaded only where needed)
+* Confirmed compatibility with WooCommerce 10.8.1 and PHP 8.4
+
 = 4.6.2 =
 *Release Date: April 2026*
 

--- a/src/backend/attribute.php
+++ b/src/backend/attribute.php
@@ -127,7 +127,10 @@ class Attribute {
 	 * Build form fields for attribute add panel
 	 */
 	public function addAttributeFields() {
-		if (isset($_POST['add_new_attribute'])) {
+		// Defense-in-depth: WooCommerce already gates this page on 'manage_product_terms'
+		// and wp_die()s on a bad nonce before this render hook fires, but guard our own
+		// option writes too (WP.org review expects it, and protects against future flow changes).
+		if (isset($_POST['add_new_attribute']) && current_user_can('manage_product_terms')) {
 			$taxonomy_id = wc_attribute_taxonomy_id_by_name(sanitize_title($_POST['attribute_label']));
 
 			$options = [
@@ -184,7 +187,9 @@ class Attribute {
 			return;
 		}
 
-		if (isset($_POST['save_attribute'])) {
+		// Defense-in-depth: see note in addAttributeFields() — guard our writes even
+		// though WooCommerce already enforces capability + nonce upstream.
+		if (isset($_POST['save_attribute']) && current_user_can('manage_product_terms')) {
 			$options = [
 				REWRITE_TERM_NAME_PREFIX . $attribute_id => [
 					'value' => isset($_POST['term_name_rewrite']),

--- a/src/backend/attribute.php
+++ b/src/backend/attribute.php
@@ -159,18 +159,18 @@ class Attribute {
 		?>
 		<div class="form-field">
 			<label for="dont_overwrite_theme"><input type="checkbox" name="dont_overwrite_theme" id="dont_overwrite_theme" value="">
-			<?php echo($this->dont_overwrite_theme_label); ?></label>
-			<p class="description"><?php echo($this->dont_overwrite_theme_description); ?></p>
+			<?php echo esc_html($this->dont_overwrite_theme_label); ?></label>
+			<p class="description"><?php echo esc_html($this->dont_overwrite_theme_description); ?></p>
 		</div>
 		<div class="form-field">
 			<label for="term_name_rewrite"><input type="checkbox" name="term_name_rewrite" id="term_name_rewrite" value="">
-			<?php echo($this->rewrite_name_label); ?></label>
-			<p class="description"><?php echo($this->rewrite_name_description); ?></p>
+			<?php echo esc_html($this->rewrite_name_label); ?></label>
+			<p class="description"><?php echo esc_html($this->rewrite_name_description); ?></p>
 		</div>
 		<div class="form-field">
 			<label for="term_desc_rewrite"><input type="checkbox" name="term_desc_rewrite" id="term_desc_rewrite" value="">
-			<?php echo($this->rewrite_desc_label); ?></label>
-			<p class="description"><?php echo($this->rewrite_desc_description); ?></p>
+			<?php echo esc_html($this->rewrite_desc_label); ?></label>
+			<p class="description"><?php echo esc_html($this->rewrite_desc_description); ?></p>
 		</div>
 		<?php
 	}
@@ -224,24 +224,24 @@ class Attribute {
 		$checked_overwrite_flag = $dont_overwrite_theme_flag == 'yes' ? ' checked' : "";
 		?>
 		<tr class="form-field">
-			<th scope="row" valign="top"><label for="dont_overwrite_theme"><?php echo($this->dont_overwrite_theme_label); ?></label></th>
+			<th scope="row" valign="top"><label for="dont_overwrite_theme"><?php echo esc_html($this->dont_overwrite_theme_label); ?></label></th>
 			<td>
 				<input type="checkbox" name="dont_overwrite_theme" id="dont_overwrite_theme_edit"<?php echo $checked_overwrite_flag; ?>>
-				<p class="description"><?php echo($this->dont_overwrite_theme_description); ?></p>
+				<p class="description"><?php echo esc_html($this->dont_overwrite_theme_description); ?></p>
 			</td>
 		</tr>
 		<tr class="form-field">
-			<th scope="row" valign="top"><label for="term_name_rewrite"><?php echo($this->rewrite_name_label); ?></label></th>
+			<th scope="row" valign="top"><label for="term_name_rewrite"><?php echo esc_html($this->rewrite_name_label); ?></label></th>
 			<td>
 				<input type="checkbox" name="term_name_rewrite" id="term_name_edit_rewrite"<?php echo $checked_name_flag; ?>>
-				<p class="description"><?php echo($this->rewrite_name_description); ?></p>
+				<p class="description"><?php echo esc_html($this->rewrite_name_description); ?></p>
 			</td>
 		</tr>
 		<tr class="form-field">
-		<th scope="row" valign="top"><label for="term_desc_rewrite"><?php echo($this->rewrite_desc_label); ?></label></th>
+		<th scope="row" valign="top"><label for="term_desc_rewrite"><?php echo esc_html($this->rewrite_desc_label); ?></label></th>
 		<td>
 				<input type="checkbox" name="term_desc_rewrite" id="term_desc_edit_rewrite"<?php echo $checked_desc_flag; ?>>
-				<p class="description"><?php echo($this->rewrite_desc_description); ?></p>
+				<p class="description"><?php echo esc_html($this->rewrite_desc_description); ?></p>
 			</td>
 		</tr>
 		<?php

--- a/src/backend/attribute.php
+++ b/src/backend/attribute.php
@@ -114,9 +114,9 @@ class Attribute {
 		add_action("woocommerce_before_attribute_delete", function () {
 			$delete_id = isset($_GET['delete']) ? absint($_GET['delete']) : 0;
 			if ($delete_id > 0) {
-				delete_option(REWRITE_TERM_NAME_PREFIX . $delete_id);
-				delete_option(REWRITE_TERM_DESC_PREFIX . $delete_id);
-				delete_option(DONT_OVERWRITE_THEME_PREFIX . $delete_id);
+				delete_option(MT2MBA_REWRITE_TERM_NAME_PREFIX . $delete_id);
+				delete_option(MT2MBA_REWRITE_TERM_DESC_PREFIX . $delete_id);
+				delete_option(MT2MBA_DONT_OVERWRITE_THEME_PREFIX . $delete_id);
 			}
 		}, 10, 2);
 	}
@@ -134,15 +134,15 @@ class Attribute {
 			$taxonomy_id = wc_attribute_taxonomy_id_by_name(sanitize_title($_POST['attribute_label']));
 
 			$options = [
-				REWRITE_TERM_NAME_PREFIX . $taxonomy_id => [
+				MT2MBA_REWRITE_TERM_NAME_PREFIX . $taxonomy_id => [
 					'value' => isset($_POST['term_name_rewrite']),
 					'autoload' => true
 				],
-				REWRITE_TERM_DESC_PREFIX . $taxonomy_id => [
+				MT2MBA_REWRITE_TERM_DESC_PREFIX . $taxonomy_id => [
 					'value' => isset($_POST['term_desc_rewrite']),
 					'autoload' => false
 				],
-				DONT_OVERWRITE_THEME_PREFIX . $taxonomy_id => [
+				MT2MBA_DONT_OVERWRITE_THEME_PREFIX . $taxonomy_id => [
 					'value' => isset($_POST['dont_overwrite_theme']),
 					'autoload' => true
 				]
@@ -191,15 +191,15 @@ class Attribute {
 		// though WooCommerce already enforces capability + nonce upstream.
 		if (isset($_POST['save_attribute']) && current_user_can('manage_product_terms')) {
 			$options = [
-				REWRITE_TERM_NAME_PREFIX . $attribute_id => [
+				MT2MBA_REWRITE_TERM_NAME_PREFIX . $attribute_id => [
 					'value' => isset($_POST['term_name_rewrite']),
 					'autoload' => true
 				],
-				REWRITE_TERM_DESC_PREFIX . $attribute_id => [
+				MT2MBA_REWRITE_TERM_DESC_PREFIX . $attribute_id => [
 					'value' => isset($_POST['term_desc_rewrite']),
 					'autoload' => false
 				],
-				DONT_OVERWRITE_THEME_PREFIX . $attribute_id => [
+				MT2MBA_DONT_OVERWRITE_THEME_PREFIX . $attribute_id => [
 					'value' => isset($_POST['dont_overwrite_theme']),
 					'autoload' => true
 				]
@@ -214,9 +214,9 @@ class Attribute {
 			}
 		}
 		// Set flags from Options database
-		$rewrite_name_flag			= get_option(REWRITE_TERM_NAME_PREFIX . $attribute_id, false);
-		$rewrite_desc_flag			= get_option(REWRITE_TERM_DESC_PREFIX . $attribute_id, false);
-		$dont_overwrite_theme_flag	= get_option(DONT_OVERWRITE_THEME_PREFIX . $attribute_id, false);
+		$rewrite_name_flag			= get_option(MT2MBA_REWRITE_TERM_NAME_PREFIX . $attribute_id, false);
+		$rewrite_desc_flag			= get_option(MT2MBA_REWRITE_TERM_DESC_PREFIX . $attribute_id, false);
+		$dont_overwrite_theme_flag	= get_option(MT2MBA_DONT_OVERWRITE_THEME_PREFIX . $attribute_id, false);
 
 		// Build row and fill field with current markup
 		$checked_name_flag = $rewrite_name_flag == 'yes' ? ' checked' : "";

--- a/src/backend/handlers/markupdeletehandler.php
+++ b/src/backend/handlers/markupdeletehandler.php
@@ -50,8 +50,9 @@ class MarkupDeleteHandler extends PriceMarkupHandler {
 
 		// Delete all Markup-by-Attribute metadata for the product using prepared statement
 		$wpdb->query($wpdb->prepare(
-			"DELETE FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key LIKE 'mt2mba_%'",
-			$product_id
+			"DELETE FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key LIKE %s",
+			$product_id,
+			$wpdb->esc_like('mt2mba_') . '%'
 		));
 	}
 	//endregion

--- a/src/backend/handlers/markupdeletehandler.php
+++ b/src/backend/handlers/markupdeletehandler.php
@@ -2,11 +2,13 @@
 namespace mt2Tech\MarkupByAttribute\Backend\Handlers;
 
 /**
- * Handles deletion of markup metadata
+ * Handles cleanup of markup metadata for the "Delete all variations" bulk action
  *
- * Used when removing variations to clean up associated markup data.
- * This handler ensures that orphaned metadata is properly removed from
- * the database when products or variations are deleted.
+ * Fires from the WooCommerce variations bulk-edit dropdown via the `delete_all`
+ * action (see Product::handleBulkPriceAction). When all of a product's variations
+ * are removed the parent product survives, but its per-term markup metadata is now
+ * orphaned, so this handler strips it. Note: this does NOT run on full product
+ * deletion — WordPress core removes the post's meta in that case.
  *
  * @package   mt2Tech\MarkupByAttribute\Backend\Handlers
  * @author    Mark Tomlinson
@@ -34,10 +36,12 @@ class MarkupDeleteHandler extends PriceMarkupHandler {
 
 	//region PUBLIC API
 	/**
-	 * Delete all markup metadata for a product
+	 * Delete all markup metadata from a product
 	 *
-	 * Removes all markup-by-attribute metadata from the database when products
-	 * or variations are deleted. This prevents orphaned data accumulation.
+	 * Invoked by the "Delete all variations" bulk action (`delete_all`). Removes the
+	 * parent product's mt2mba_* metadata, which becomes orphaned once its variations
+	 * are gone. This is not a post-deletion hook — deleting the product itself is
+	 * cleaned up by WordPress core.
 	 *
 	 * @since 4.0.0
 	 * @param string $unused1    Unused parameter (maintaining interface compatibility)

--- a/src/backend/handlers/pricemarkuphandler.php
+++ b/src/backend/handlers/pricemarkuphandler.php
@@ -45,14 +45,6 @@ abstract class PriceMarkupHandler {
 	 * @param float  $base_price  The base price of the product before markup
 	 */
 	public function __construct($bulk_action, $product_id, $base_price) {
-		// Create 'regular_price' string in one place
-		if (!defined('REGULAR_PRICE')) {
-			define('REGULAR_PRICE', 'regular_price');
-		}
-		if (!defined('SALE_PRICE')) {
-			define('SALE_PRICE', 'sale_price');
-		}
-
 		// Extract price_type from bulk_action (e.g., "variable_regular_price" -> "regular_price")
 		if ($bulk_action) {
 			$bulk_action_array = explode("_", $bulk_action);

--- a/src/backend/handlers/pricesethandler.php
+++ b/src/backend/handlers/pricesethandler.php
@@ -84,7 +84,7 @@ class PriceSetHandler extends PriceMarkupHandler {
 		$markup_table = $this->buildMarkupTable($attribute_data, $product_id);
 
 		// Bulk save product markup values
-		if ($this->price_type === REGULAR_PRICE) {
+		if ($this->price_type === MT2MBA_REGULAR_PRICE) {
 			$this->bulkSaveProductMarkupValues($markup_table);
 		}
 
@@ -130,10 +130,10 @@ class PriceSetHandler extends PriceMarkupHandler {
 		delete_post_meta($product_id, "mt2mba_base_{$this->price_type}");
 
 		// If clearing the Regular Price, also clean up sale price metadata and descriptions
-		if ($this->price_type == REGULAR_PRICE) {
+		if ($this->price_type == MT2MBA_REGULAR_PRICE) {
 
 			// Remove Sales Price metadata
-			delete_post_meta($product_id, "mt2mba_base_" . SALE_PRICE);
+			delete_post_meta($product_id, "mt2mba_base_" . MT2MBA_SALE_PRICE);
 
 			// Bulk-fetch all variation descriptions in a single query
 			global $wpdb, $mt2mba_utility;
@@ -148,7 +148,7 @@ class PriceSetHandler extends PriceMarkupHandler {
 			// Process descriptions in PHP — strip markup information
 			$updates = [];
 			foreach ($descriptions as $row) {
-				$markup_pos = strpos($row->meta_value, PRODUCT_MARKUP_DESC_BEG);
+				$markup_pos = strpos($row->meta_value, MT2MBA_PRODUCT_MARKUP_DESC_BEG);
 
 				// If no markup information, skip variation
 				if ($markup_pos === false) {
@@ -163,8 +163,8 @@ class PriceSetHandler extends PriceMarkupHandler {
 					$updates[] = [
 						'id'          => (int) $row->post_id,
 						'description' => $mt2mba_utility->removeBracketedString(
-							PRODUCT_MARKUP_DESC_BEG,
-							PRODUCT_MARKUP_DESC_END,
+							MT2MBA_PRODUCT_MARKUP_DESC_BEG,
+							MT2MBA_PRODUCT_MARKUP_DESC_END,
 							$row->meta_value
 						),
 					];
@@ -224,10 +224,10 @@ class PriceSetHandler extends PriceMarkupHandler {
 
 				if (!empty($markup)) {
 					// Determine price to calculate markup against based on settings
-					if ($this->price_type === REGULAR_PRICE || MT2MBA_SALE_PRICE_MARKUP === 'yes') {
+					if ($this->price_type === MT2MBA_REGULAR_PRICE || MT2MBA_SALE_PRICE_MARKUP === 'yes') {
 						$price = $this->base_price;
 					} else {
-						$price = get_metadata("post", $product_id, "mt2mba_base_" . REGULAR_PRICE, true);
+						$price = get_metadata("post", $product_id, "mt2mba_base_" . MT2MBA_REGULAR_PRICE, true);
 					}
 
 					// Calculate markup value: percentage markups are calculated against the price,
@@ -276,7 +276,7 @@ class PriceSetHandler extends PriceMarkupHandler {
 		// record before rewriting it appears to be the only way to update the cache.
 		delete_post_meta($product_id, "mt2mba_base_{$this->price_type}");
 		update_post_meta($product_id, "mt2mba_base_{$this->price_type}", $rounded_base);
-		if ($this->price_type === REGULAR_PRICE) {
+		if ($this->price_type === MT2MBA_REGULAR_PRICE) {
 			set_transient('mt2mba_current_base_' . $product_id, $rounded_base, HOUR_IN_SECONDS);
 		}
 		return MT2MBA_HIDE_BASE_PRICE === 'no' ?
@@ -336,15 +336,15 @@ class PriceSetHandler extends PriceMarkupHandler {
 	protected function buildVariationDescription($current_description, $base_price_description, $markup_description, $variation_price): string {
 		global $mt2mba_utility;
 
-		if ($this->price_type === REGULAR_PRICE) {
+		if ($this->price_type === MT2MBA_REGULAR_PRICE) {
 			// Build new description for regular prices and reapply markup operations
 			$description = "";
 
 			// Preserve existing non-markup description content unless overwriting
 			if (MT2MBA_DESC_BEHAVIOR !== "overwrite") {
 				$description = $mt2mba_utility->removeBracketedString(
-					PRODUCT_MARKUP_DESC_BEG,
-					PRODUCT_MARKUP_DESC_END,
+					MT2MBA_PRODUCT_MARKUP_DESC_BEG,
+					MT2MBA_PRODUCT_MARKUP_DESC_END,
 					$current_description
 				);
 			}
@@ -356,10 +356,10 @@ class PriceSetHandler extends PriceMarkupHandler {
 
 			// Add markup information if we have markups and behavior allows it
 			if ($markup_description && $variation_price != null && MT2MBA_DESC_BEHAVIOR !== "ignore") {
-				$description .= PRODUCT_MARKUP_DESC_BEG .
+				$description .= MT2MBA_PRODUCT_MARKUP_DESC_BEG .
 							$base_price_description .
 							$markup_description .
-							PRODUCT_MARKUP_DESC_END;
+							MT2MBA_PRODUCT_MARKUP_DESC_END;
 			}
 
 			return trim($description);
@@ -571,12 +571,12 @@ class PriceSetHandler extends PriceMarkupHandler {
 	 * @return	string				Formatted regular price for description
 	 */
 	private function getRegularPriceForDescription($product_id) {
-		if ($this->price_type === REGULAR_PRICE) {
+		if ($this->price_type === MT2MBA_REGULAR_PRICE) {
 			// We're setting regular price, use the current value being set
 			return $this->base_price_formatted;
 		} else {
 			// We're setting sale price, get stored regular price
-			$regular_price = get_metadata("post", $product_id, "mt2mba_base_" . REGULAR_PRICE, true);
+			$regular_price = get_metadata("post", $product_id, "mt2mba_base_" . MT2MBA_REGULAR_PRICE, true);
 			return is_numeric($regular_price) ? strip_tags(wc_price(abs($regular_price))) : '';
 		}
 	}

--- a/src/backend/handlers/pricesethandler.php
+++ b/src/backend/handlers/pricesethandler.php
@@ -1,6 +1,7 @@
 <?php
 namespace mt2Tech\MarkupByAttribute\Backend\Handlers;
 use mt2Tech\MarkupByAttribute\Utility as Utility;
+use Throwable;
 
 /**
  * Handles setting product prices and applying markups
@@ -15,6 +16,21 @@ use mt2Tech\MarkupByAttribute\Utility as Utility;
  * @since     4.0.0
  */
 class PriceSetHandler extends PriceMarkupHandler {
+	//region PROPERTIES
+	/**
+	 * Whether this handler owns (starts/commits/rolls back) its own database transaction.
+	 *
+	 * MySQL does not support nested transactions — a START TRANSACTION while another
+	 * is open implicitly COMMITs the open one. When a caller wraps multiple handler
+	 * runs in its own transaction (e.g., Product::handleMarkupReapplication wrapping
+	 * the regular- and sale-price passes), it must pass false so this handler defers
+	 * transaction control to that outermost owner.
+	 *
+	 * @var bool
+	 */
+	protected $owns_transaction;
+	//endregion
+
 	//region INITIALIZATION
 	/**
 	 * Initialize PriceSetHandler with product and markup information
@@ -22,12 +38,14 @@ class PriceSetHandler extends PriceMarkupHandler {
 	 * Extracts the base price from the bulk action data and initializes the parent handler.
 	 *
 	 * @since 4.0.0
-	 * @param string $bulk_action The bulk action being performed
-	 * @param array  $data        The data for price setting (contains 'value' key)
-	 * @param int    $product_id  The ID of the product
-	 * @param array  $variations  List of variation IDs
+	 * @param string $bulk_action      The bulk action being performed
+	 * @param array  $data             The data for price setting (contains 'value' key)
+	 * @param int    $product_id       The ID of the product
+	 * @param array  $variations       List of variation IDs
+	 * @param bool   $owns_transaction False when the caller manages the transaction (see property docblock)
 	 */
-	public function __construct($bulk_action, $data, $product_id, $variations) {
+	public function __construct($bulk_action, $data, $product_id, $variations, $owns_transaction = true) {
+		$this->owns_transaction = (bool) $owns_transaction;
 		// Convert localized decimal input to standardized format using WooCommerce
 		$cleaned_value = wc_format_decimal($data["value"], false, true);
 		parent::__construct($bulk_action, $product_id, is_numeric($cleaned_value) ? (float) $cleaned_value : '');
@@ -485,8 +503,11 @@ class PriceSetHandler extends PriceMarkupHandler {
 			}
 		}
 
-		// Start transaction for data consistency
-		$wpdb->query('START TRANSACTION');
+		// Start transaction for data consistency — but only when no caller owns one
+		// already (a nested START TRANSACTION would implicitly COMMIT the outer one)
+		if ($this->owns_transaction) {
+			$wpdb->query('START TRANSACTION');
+		}
 
 		try {
 			// Delete existing price records first
@@ -526,10 +547,15 @@ class PriceSetHandler extends PriceMarkupHandler {
 				$wpdb->query($wpdb->prepare($sql, $description_values));
 			}
 
-			$wpdb->query('COMMIT');
+			if ($this->owns_transaction) {
+				$wpdb->query('COMMIT');
+			}
 
-		} catch (Exception $e) {
-			$wpdb->query('ROLLBACK');
+		} catch (Throwable $e) {
+			if ($this->owns_transaction) {
+				$wpdb->query('ROLLBACK');
+			}
+			// Re-throw so a transaction-owning caller can roll back and report
 			throw $e;
 		}
 	}

--- a/src/backend/handlers/pricesethandler.php
+++ b/src/backend/handlers/pricesethandler.php
@@ -423,8 +423,9 @@ class PriceSetHandler extends PriceMarkupHandler {
 		$wpdb->query($wpdb->prepare(
 			"DELETE FROM {$wpdb->postmeta}
 			WHERE post_id = %d
-			AND meta_key LIKE 'mt2mba_%_markup_amount'",
-			$this->product_id
+			AND meta_key LIKE %s",
+			$this->product_id,
+			$wpdb->esc_like('mt2mba_') . '%' . $wpdb->esc_like('_markup_amount')
 		));
 
 		// Build complete query with proper placeholders

--- a/src/backend/product.php
+++ b/src/backend/product.php
@@ -2,6 +2,7 @@
 namespace mt2Tech\MarkupByAttribute\Backend;
 //use mt2Tech\MarkupByAttribute\Backend\Handlers;
 use mt2Tech\MarkupByAttribute\Utility as Utility;
+use Throwable;
 
 /**
  * Main class for handling product backend actions.
@@ -132,13 +133,13 @@ class Product {
 
 				wp_send_json_success(['completed' => true]);
 
-			} catch (Exception $e) {
+			} catch (Throwable $e) {
 				// Rollback transaction on any error to maintain data integrity
 				$wpdb->query('ROLLBACK');
 				throw $e;
 			}
 
-		} catch (Exception $e) {
+		} catch (Throwable $e) {
 			wp_send_json_error(['message' => $e->getMessage()]);
 		}
 	}
@@ -322,15 +323,17 @@ class Product {
 	 * @param	array	$variations	List of variation IDs
 	 */
 	private function processVariationsWithMarkup($product_id, $variations): void {
+		// Both passes run inside handleMarkupReapplication()'s transaction, so the
+		// handlers must not start their own (owns_transaction = false)
 		$base_regular_price = get_post_meta($product_id, 'mt2mba_base_regular_price', true);
 		$data = ['value' => $base_regular_price];
-		$handler = new Handlers\PriceSetHandler('variable_regular_price', $data, $product_id, $variations);
+		$handler = new Handlers\PriceSetHandler('variable_regular_price', $data, $product_id, $variations, false);
 		$handler->processProductMarkups('variable_regular_price', $data, $product_id, $variations);
 
 		$base_sale_price = get_post_meta($product_id, 'mt2mba_base_sale_price', true);
 		if (!empty($base_sale_price)) {
 			$data = ['value' => $base_sale_price];
-			$handler = new Handlers\PriceSetHandler('variable_sale_price', $data, $product_id, $variations);
+			$handler = new Handlers\PriceSetHandler('variable_sale_price', $data, $product_id, $variations, false);
 			$handler->processProductMarkups('variable_sale_price', $data, $product_id, $variations);
 		}
 	}

--- a/src/backend/product.php
+++ b/src/backend/product.php
@@ -241,6 +241,17 @@ class Product {
 
 		// Invoke the processProductMarkups() function from the class that was decided above
 		$handler->processProductMarkups((string) $bulk_action, (array) $data, (string) $product_id, (array) $variations);
+
+		// The handlers above write meta directly via $wpdb (DELETE/INSERT), which bypasses
+		// WordPress's object cache. WooCommerce syncs the parent after this hook, but never
+		// invalidates the individual variations — so on a persistent object cache (Redis/
+		// Memcached) stale variation prices/descriptions would keep serving. Flush the post
+		// + post_meta cache for the parent and every edited variation *before* WC's post-hook
+		// sync, so that sync recomputes from fresh data. 🌸
+		clean_post_cache($product_id);
+		foreach ($variations as $variation_id) {
+			clean_post_cache($variation_id);
+		}
 	}
 	//endregion
 

--- a/src/backend/product.php
+++ b/src/backend/product.php
@@ -155,6 +155,11 @@ class Product {
 	public function getFormattedBasePrice(): void {
 		check_ajax_referer('handleMarkupReapplication', 'security');
 
+		if (!current_user_can('edit_products')) {
+			wp_send_json_error(['message' => __('Permission denied', 'markup-by-attribute-for-woocommerce')]);
+			return;
+		}
+
 		$product_id = isset($_POST['product_id']) ? absint($_POST['product_id']) : 0;
 		if (!$product_id) {
 			wp_send_json_error();
@@ -184,6 +189,11 @@ class Product {
 	 */
 	public function refreshProductGeneralPanel(): void {
 		check_ajax_referer('handleMarkupReapplication', 'security');
+
+		if (!current_user_can('edit_products')) {
+			wp_send_json_error(['message' => __('Permission denied', 'markup-by-attribute-for-woocommerce')]);
+			return;
+		}
 
 		$product_id = isset($_POST['product_id']) ? absint($_POST['product_id']) : 0;
 

--- a/src/backend/productlist.php
+++ b/src/backend/productlist.php
@@ -417,8 +417,13 @@ class ProductList {
 	public function refreshProductRow(): void {
 		check_ajax_referer('handleMarkupReapplication', 'security');
 
-		$product_id = absint($_REQUEST['product_id']);
-		$product = wc_get_product($product_id);
+		if (!current_user_can('edit_products')) {
+			wp_send_json_error(['message' => __('Permission denied', 'markup-by-attribute-for-woocommerce')]);
+			return;
+		}
+
+		$product_id = isset($_REQUEST['product_id']) ? absint($_REQUEST['product_id']) : 0;
+		$product = $product_id ? wc_get_product($product_id) : false;
 
 		if (!$product) {
 			wp_send_json_error(['message' => __('Product not found', 'markup-by-attribute-for-woocommerce')]);

--- a/src/backend/productlist.php
+++ b/src/backend/productlist.php
@@ -199,25 +199,27 @@ class ProductList {
 	 * @param int    $product_id Product ID
 	 */
 	public function renderColumnContent(string $column, int $product_id): void {
+		// Bail immediately for columns that aren't ours — avoids hydrating the
+		// product object and reading meta for every WooCommerce/foreign column.
+		if ($column !== 'product_attributes' && $column !== 'mt2mba_base_price') {
+			return;
+		}
+
 		// Get product
 		$product = wc_get_product($product_id);
 		if (!$product) return;	// No product!
 
-		// Get appropriate base price
-		$base_price = '';
-		if ($product->is_on_sale()) {
-			$base_price = get_post_meta($product_id, 'mt2mba_base_sale_price', true);
-		} else {
-			$base_price = get_post_meta($product_id, 'mt2mba_base_regular_price', true);
-		}
-
 		// Cache whether this is a variable product on first check
 		if (!isset($this->variable_products[$product_id])) {
-			$this->variable_products[$product_id] = $product && $product->is_type('variable');
+			$this->variable_products[$product_id] = $product->is_type('variable');
 		}
 
 		switch ($column) {
 			case 'product_attributes':
+				// Base price is only needed for the Reprice link in this column
+				$base_price = $product->is_on_sale()
+					? get_post_meta($product_id, 'mt2mba_base_sale_price', true)
+					: get_post_meta($product_id, 'mt2mba_base_regular_price', true);
 				$this->renderAttributesColumn($product, $product_id, $base_price);
 				break;
 

--- a/src/backend/productlist.php
+++ b/src/backend/productlist.php
@@ -328,33 +328,42 @@ class ProductList {
 	 * @param WP_Query $query WordPress query object
 	 */
 	public function filterProductsByAttribute(object $query): void {
-		global $typenow, $wp_query;
+		global $typenow;
 
-		if ($typenow == 'product' && is_admin()) {
-			$filter_attribute = isset($_GET['filter_product_attribute']) ? sanitize_text_field($_GET['filter_product_attribute']) : '';
+		// Only touch the main product-list query. pre_get_posts fires for many
+		// secondary queries (quick-edit AJAX, dashboard widgets, menu counts,
+		// Heartbeat), and our filter has no business modifying those.
+		if (!is_admin() || $typenow !== 'product' || !$query->is_main_query()) {
+			return;
+		}
 
-			if (!empty($filter_attribute)) {
-				$taxonomy = wc_attribute_taxonomy_name($filter_attribute);
+		$filter_attribute = isset($_GET['filter_product_attribute']) ? sanitize_text_field($_GET['filter_product_attribute']) : '';
 
-				if (taxonomy_exists($taxonomy)) {
-					// For taxonomy attributes
-					$query->set('tax_query', array(array(
-						'taxonomy' => $taxonomy,
-						'field' => 'slug',
-						'terms' => get_terms($taxonomy, array('fields' => 'slugs')),
-						'operator' => 'IN'
-					)));
-				} else {
-					// For custom product attributes
-					$meta_query = $query->get('meta_query', array());
-					$meta_query[] = array(
-						'key' => '_product_attributes',
-						'value' => '"' . $filter_attribute . '"',
-						'compare' => 'LIKE'
-					);
-					$query->set('meta_query', $meta_query);
-				}
-			}
+		if (empty($filter_attribute)) {
+			return;
+		}
+
+		// The Attributes-column links pass the full taxonomy name ('pa_color')
+		// for global attributes. Resolve as-is first; only fall back to the
+		// pa_-prefixing helper for a raw name ('color') so we never double-prefix.
+		$taxonomy = taxonomy_exists($filter_attribute) ? $filter_attribute : wc_attribute_taxonomy_name($filter_attribute);
+
+		if (taxonomy_exists($taxonomy)) {
+			// Global taxonomy attribute: "has any term in this attribute" is a
+			// single EXISTS clause — no need to enumerate every slug into IN(...).
+			$query->set('tax_query', array(array(
+				'taxonomy' => $taxonomy,
+				'operator' => 'EXISTS'
+			)));
+		} else {
+			// Custom (local) product attribute
+			$meta_query = $query->get('meta_query', array());
+			$meta_query[] = array(
+				'key' => '_product_attributes',
+				'value' => '"' . $filter_attribute . '"',
+				'compare' => 'LIKE'
+			);
+			$query->set('meta_query', $meta_query);
 		}
 	}
 	//endregion

--- a/src/backend/term.php
+++ b/src/backend/term.php
@@ -128,14 +128,18 @@ class Term {
 			return $columns;
 		}, 10);
 
-		// Add content to Markup column
-		add_action("manage_{$taxonomy}_custom_column", function ($string, $column_name, $term_id) {
+		// Add content to Markup column.
+		// NOTE: for *taxonomy term* columns this hook is a filter — core echoes the
+		// returned value — so we must append to and return the incoming $string rather
+		// than echoing. Returning null (or our own content alone) would wipe whatever a
+		// previous callback added, including other plugins' columns. 🌸
+		add_filter("manage_{$taxonomy}_custom_column", function ($string, $column_name, $term_id) {
 			if ($column_name == 'markup') {
 				global $mt2mba_utility;
 				$markup = get_term_meta($term_id, 'mt2mba_markup', true);
-				echo esc_html($mt2mba_utility->sanitizeMarkupForDisplay(wc_format_localized_decimal($markup)));
+				$string .= esc_html($mt2mba_utility->sanitizeMarkupForDisplay(wc_format_localized_decimal($markup)));
 			}
-			return;
+			return $string;
 		}, 10, 3);
 
 		// Make Markup column sortable

--- a/src/backend/term.php
+++ b/src/backend/term.php
@@ -257,8 +257,8 @@ class Term {
 
 			// Check global attribute settings for term name/description rewriting
 			// These options control whether markup should be visible in dropdowns
-			$rewrite_name_flag	= get_option(REWRITE_TERM_NAME_PREFIX . wc_attribute_taxonomy_id_by_name($taxonomy_name));
-			$rewrite_desc_flag	= get_option(REWRITE_TERM_DESC_PREFIX . wc_attribute_taxonomy_id_by_name($taxonomy_name));
+			$rewrite_name_flag	= get_option(MT2MBA_REWRITE_TERM_NAME_PREFIX . wc_attribute_taxonomy_id_by_name($taxonomy_name));
+			$rewrite_desc_flag	= get_option(MT2MBA_REWRITE_TERM_DESC_PREFIX . wc_attribute_taxonomy_id_by_name($taxonomy_name));
 
 			// Check markup sign for proper formatting (discount vs. surcharge)
 			$is_negative = strpos($markup, '-') === 0;

--- a/src/backend/term.php
+++ b/src/backend/term.php
@@ -157,9 +157,9 @@ class Term {
 		?>
 		<div class="form-field">
 			<?php wp_nonce_field('mt2mba_add_term', 'mt2mba_term_nonce'); ?>
-			<label for="term_markup"><?php echo($this->markup_label); ?></label>
-			<input type="text" placeholder="<?php echo($this->placeholder); ?>" name="term_markup" id="term_add_markup" value="">
-			<p class="description"><?php echo($this->markup_description); ?></p>
+			<label for="term_markup"><?php echo esc_html($this->markup_label); ?></label>
+			<input type="text" placeholder="<?php echo esc_attr($this->placeholder); ?>" name="term_markup" id="term_add_markup" value="">
+			<p class="description"><?php echo esc_html($this->markup_description); ?></p>
 		</div>
 		<?php
 	}
@@ -174,10 +174,10 @@ class Term {
 		// Build row and fill field with current markup
 		?>
 		<tr class="form-field">
-			<th scope="row" valign="top"><label for="term_markup"><?php echo($this->markup_label); ?></label></th>
+			<th scope="row" valign="top"><label for="term_markup"><?php echo esc_html($this->markup_label); ?></label></th>
 			<td>
-				<input type="text" placeholder="<?php echo($this->placeholder); ?>" name="term_markup" id="term_edit_markup" value="<?php echo esc_attr($term_markup) ? esc_attr($term_markup) : ''; ?>">
-				<p class="description"><?php echo($this->markup_description); ?></p>
+				<input type="text" placeholder="<?php echo esc_attr($this->placeholder); ?>" name="term_markup" id="term_edit_markup" value="<?php echo esc_attr($term_markup) ? esc_attr($term_markup) : ''; ?>">
+				<p class="description"><?php echo esc_html($this->markup_description); ?></p>
 			</td>
 		</tr>
 		<?php

--- a/src/backend/term.php
+++ b/src/backend/term.php
@@ -31,6 +31,9 @@ class Term {
 
 	/** @var string Placeholder text for markup input */
 	private $placeholder;
+
+	/** @var bool Re-entrancy guard: true only while wp_update_term() is running */
+	private static $is_rewriting_term = false;
 	//endregion
 
 	//region INSTANCE MANAGEMENT
@@ -226,10 +229,11 @@ class Term {
 			return;
 		}
 
-		// Prevent infinite recursion: wp_update_term() triggers this hook again
-		// Use a constant flag to detect if we're already processing this term
-		if (defined('MT2MBA_ATTRB_RECURSION')) return;
-		define('MT2MBA_ATTRB_RECURSION', TRUE);
+		// Prevent infinite recursion: wp_update_term() (below) re-fires this hook for the
+		// same term. A request-scoped static flag — raised only around that call — catches
+		// the re-entrant pass while still letting every distinct term in a batch get
+		// processed. (A permanent define() here skipped all terms after the first.) 🌸
+		if (self::$is_rewriting_term) return;
 
 		global $mt2mba_utility;
 
@@ -287,6 +291,9 @@ class Term {
 
 		// Rewrite term if name and/or description have changed
 		if ($term->name != $name || $term->description != $description) {
+			// Raise the guard only around this call (it re-fires edited_{taxonomy}); lower
+			// it immediately after so the next term in a batch processes normally.
+			self::$is_rewriting_term = true;
 			wp_update_term(
 				$term_id,
 				$taxonomy_name,
@@ -295,6 +302,7 @@ class Term {
 					'description' => sanitize_textarea_field(trim($description))
 				)
 			);
+			self::$is_rewriting_term = false;
 		}
 	}
 	//endregion

--- a/src/frontend/options.php
+++ b/src/frontend/options.php
@@ -103,10 +103,10 @@ class Options {
 		// Exit early based on plugin configuration and compatibility settings
 		if (
 			// Don't overwrite if admin configured this attribute to preserve theme styling
-			get_option(DONT_OVERWRITE_THEME_PREFIX . $attribute_id) == 'yes' ||
+			get_option(MT2MBA_DONT_OVERWRITE_THEME_PREFIX . $attribute_id) == 'yes' ||
 
 			// Prevent duplicate markup display if markup is already included in term names
-			get_option(REWRITE_TERM_NAME_PREFIX . $attribute_id) == 'yes'
+			get_option(MT2MBA_REWRITE_TERM_NAME_PREFIX . $attribute_id) == 'yes'
 		) {
 			return $html;
 		}

--- a/src/frontend/options.php
+++ b/src/frontend/options.php
@@ -106,7 +106,7 @@ class Options {
 			get_option(DONT_OVERWRITE_THEME_PREFIX . $attribute_id) == 'yes' ||
 
 			// Prevent duplicate markup display if markup is already included in term names
-			get_option(REWRITE_TERM_NAME_PREFIX . wc_attribute_taxonomy_id_by_name($attribute)) == 'yes'
+			get_option(REWRITE_TERM_NAME_PREFIX . $attribute_id) == 'yes'
 		) {
 			return $html;
 		}

--- a/src/utility/general.php
+++ b/src/utility/general.php
@@ -225,8 +225,8 @@ class General {
 		$number_pattern = '[0-9.,\s%\p{Sc}A-Z]*';
 
 		// Convert Add and Subtract constants to regex with international number pattern
-		$add_pattern = '/(?:^|\s)' . str_replace('%s', $number_pattern, preg_quote(MT2MBA_MARKUP_NAME_PATTERN_ADD)) . '/u';
-		$subtract_pattern = '/(^|\s)' . str_replace('%s', $number_pattern, preg_quote(MT2MBA_MARKUP_NAME_PATTERN_SUBTRACT)) . '/u';
+		$add_pattern = '/(?:^|\s)' . str_replace('%s', $number_pattern, preg_quote(MT2MBA_MARKUP_NAME_PATTERN_ADD, '/')) . '/u';
+		$subtract_pattern = '/(^|\s)' . str_replace('%s', $number_pattern, preg_quote(MT2MBA_MARKUP_NAME_PATTERN_SUBTRACT, '/')) . '/u';
 
 		// Decoded HTML encoding
 		$text = html_entity_decode($text);

--- a/src/utility/notices.php
+++ b/src/utility/notices.php
@@ -160,12 +160,12 @@ class Notices {
 				);
 				if (!get_option("mt2mba_dismissed_{$dismiss_option}")) {
 					?><div
-						class="notice mt2mba-notice notice-<?php echo $type;
+						class="notice mt2mba-notice notice-<?php echo esc_attr($type);
 						if ($dismiss_option) {
 							echo ' is-dismissible" data-dismiss-url="' . esc_url($dismiss_url);
 						} ?>">
-						<strong><em><?php echo(MT2MBA_PLUGIN_NAME . ' ' . $type); ?></em></strong>
-						<p><?php echo($message); ?></p>
+						<strong><em><?php echo esc_html(MT2MBA_PLUGIN_NAME . ' ' . $type); ?></em></strong>
+						<p><?php echo wp_kses_post($message); ?></p>
 					</div><?php
 				}	//	End if
 			}	//	End function

--- a/src/utility/notices.php
+++ b/src/utility/notices.php
@@ -26,6 +26,18 @@ class Notices {
 	 * @since 1.0.0
 	 */
 	private static ?self $instance = null;
+
+	/**
+	 * Whether at least one undismissed notice will render this request.
+	 *
+	 * Set by notice() when a notice is queued for display, and read by
+	 * enqueueNoticeScripts() to avoid loading the dismissal JS on every
+	 * admin page when there is nothing to dismiss.
+	 *
+	 * @var bool
+	 * @since 4.6.3
+	 */
+	private bool $has_active_notices = false;
 	//endregion
 
 	//region INSTANCE MANAGEMENT
@@ -81,10 +93,17 @@ class Notices {
 	 * @since 1.0.0
 	 */
 	public function enqueueNoticeScripts(): void {
+		// Only load the dismissal script when an undismissed notice is actually
+		// present — no need to ship it on every admin page.
+		if (!$this->has_active_notices) {
+			return;
+		}
 		wp_enqueue_script (
 			'jq-mt2mba-clear-notices',
 			MT2MBA_PLUGIN_URL . 'src/js/jq-mt2mba-clear-notices.js',
-			array('jquery')
+			array('jquery'),
+			MT2MBA_VERSION,
+			true
 		);
 	}
 
@@ -148,6 +167,13 @@ class Notices {
 	 * @param string $dismiss_option Unique identifier for dismissal tracking
 	 */
 	private function notice(string $type, string $message, string $dismiss_option): void {
+		// Nothing to show if the user already dismissed this notice; skip queuing
+		// it so enqueueNoticeScripts() can tell whether the dismissal JS is needed.
+		if (get_option("mt2mba_dismissed_{$dismiss_option}")) {
+			return;
+		}
+		$this->has_active_notices = true;
+
 		add_action (
 			'admin_notices',
 			function() use ($type, $message, $dismiss_option) {

--- a/src/utility/upgrades/db_upgrade_2_0.php
+++ b/src/utility/upgrades/db_upgrade_2_0.php
@@ -56,8 +56,8 @@ class Db_Upgrade_2_0 implements UpgradeInterface {
 		$last_parent_id = '';
 		$results = $wpdb->get_results("SELECT * FROM {$wpdb->prefix}postmeta WHERE `meta_value` LIKE '%" . MT2MBA_PRICE_META . "%'");
 		foreach ($results as $row) {
-			if ((strpos($row->meta_value, PRODUCT_MARKUP_DESC_BEG) === FALSE) && (strpos($row->meta_value, MT2MBA_PRICE_META) !== FALSE)) {
-				update_post_meta($row->post_id, $row->meta_key, PRODUCT_MARKUP_DESC_BEG . $row->meta_value . PRODUCT_MARKUP_DESC_END);
+			if ((strpos($row->meta_value, MT2MBA_PRODUCT_MARKUP_DESC_BEG) === FALSE) && (strpos($row->meta_value, MT2MBA_PRICE_META) !== FALSE)) {
+				update_post_meta($row->post_id, $row->meta_key, MT2MBA_PRODUCT_MARKUP_DESC_BEG . $row->meta_value . MT2MBA_PRODUCT_MARKUP_DESC_END);
 			}
 			$v_product = get_post($row->post_id, 'ARRAY_A');
 			if ($last_parent_id != $v_product['post_parent']) {


### PR DESCRIPTION
## Summary
Security & performance release. 15 individually-tested fixes plus docs, all unit-tested (problem-before / fix-after, clean log) before sign-off, then soak-tested ~3 days on the live test box and exercised with full CRUD (products, attributes, terms) on the BackRev box (WP 5.7 / WC 5.0 / PHP 7.4).

## Security
- Capability checks (`edit_products` / `manage_product_terms`) on all AJAX handlers + attribute option writes (#3, #4)
- Escaped all admin output to close translation-file stored-XSS vector (#5)
- Escaped literal underscores in meta-key LIKE queries (#6)
- Prefixed all global PHP constants with `MT2MBA_` (#14)

## Bug Fixes
- Truly atomic markup reapplication — real nested-transaction rollback (#1, #2)
- Invalidate variation caches after bulk price edits (#11)
- Term Markup column no longer wipes other plugins' column content (#12)
- Pass delimiter to `preg_quote` in `stripMarkupAnnotation` (#13)
- Scope term-save recursion guard to one `wp_update_term` call (#15)

## Performance
- Skip product hydration for foreign product-list columns (#7)
- `EXISTS` + main-query guard for attribute filter (#8)
- Reuse cached taxonomy ID on storefront dropdown (#10)

## Maintenance
- Versioned + gated admin script/style enqueues (#9)
- Version bumped to 4.6.3 (schema stays 4.6.0 — no DB change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
